### PR TITLE
adding props to the VCreateExerciseButton component

### DIFF
--- a/src/components/atoms/VCreateExerciseButton.vue
+++ b/src/components/atoms/VCreateExerciseButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link to="" exact>
+  <router-link :to="pathUrl" exact>
     <button class="btn-create-exercise">
       <v-plus-icon class="btn-create-exercise__icon" />
     </button>
@@ -13,6 +13,12 @@ export default {
   name: "VCreateExerciseButton",
   components: {
     VPlusIcon,
+  },
+  props: {
+    pathUrl: {
+      type: String,
+      default: "",
+    },
   },
 };
 </script>


### PR DESCRIPTION
**What issue/feature/bugfix/improvement did you solve?**
---
I want to make the `VCreateExerciseButton` component more dynamic when we want to add a link that will be directed to that component.

**How you resolve the issue**
---
Add a `pathUrl` props to the `VCreateExerciseButton` component with a default empty string instead of writing the link directly to the component