### PR TITLE
renaming components

### DIFF
--- a/src/components/atoms/IconComponents/VIconBarbleOff.vue
+++ b/src/components/atoms/IconComponents/VIconBarbleOff.vue
@@ -28,7 +28,7 @@
 
 <script>
 export default {
-  name: "VBarbleOffIcon",
+  name: "VIconBarbleOff",
 };
 </script>
 

--- a/src/components/atoms/IconComponents/VIconCalendarTime.vue
+++ b/src/components/atoms/IconComponents/VIconCalendarTime.vue
@@ -11,14 +11,20 @@
     stroke-linejoin="round"
   >
     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-    <path d="M4 19l4 -6l4 2l4 -5l4 4l0 5l-16 0"></path>
-    <path d="M4 12l3 -4l4 2l5 -6l4 4"></path>
+    <path
+      d="M11.795 21h-6.795a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v4"
+    ></path>
+    <path d="M18 18m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"></path>
+    <path d="M15 3v4"></path>
+    <path d="M7 3v4"></path>
+    <path d="M3 11h16"></path>
+    <path d="M18 16.496v1.504l1 1"></path>
   </svg>
 </template>
 
 <script>
 export default {
-  name: "VChartAreaLineIcon",
+  name: "VIconCalendarTime",
 };
 </script>
 

--- a/src/components/atoms/IconComponents/VIconChartAreaLine.vue
+++ b/src/components/atoms/IconComponents/VIconChartAreaLine.vue
@@ -11,20 +11,14 @@
     stroke-linejoin="round"
   >
     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-    <path
-      d="M11.795 21h-6.795a2 2 0 0 1 -2 -2v-12a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v4"
-    ></path>
-    <path d="M18 18m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"></path>
-    <path d="M15 3v4"></path>
-    <path d="M7 3v4"></path>
-    <path d="M3 11h16"></path>
-    <path d="M18 16.496v1.504l1 1"></path>
+    <path d="M4 19l4 -6l4 2l4 -5l4 4l0 5l-16 0"></path>
+    <path d="M4 12l3 -4l4 2l5 -6l4 4"></path>
   </svg>
 </template>
 
 <script>
 export default {
-  name: "VCalendarTimeIcon",
+  name: "VIconChartAreaLine",
 };
 </script>
 

--- a/src/components/atoms/IconComponents/VIconPlus.vue
+++ b/src/components/atoms/IconComponents/VIconPlus.vue
@@ -11,16 +11,14 @@
     stroke-linejoin="round"
   >
     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-    <path
-      d="M19 8.71l-5.333 -4.148a2.666 2.666 0 0 0 -3.274 0l-5.334 4.148a2.665 2.665 0 0 0 -1.029 2.105v7.2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-7.2c0 -.823 -.38 -1.6 -1.03 -2.105"
-    ></path>
-    <path d="M16 15c-2.21 1.333 -5.792 1.333 -8 0"></path>
+    <path d="M12 5l0 14"></path>
+    <path d="M5 12l14 0"></path>
   </svg>
 </template>
 
 <script>
 export default {
-  name: "VSmartHomeIcon",
+  name: "VIconPlus",
 };
 </script>
 

--- a/src/components/atoms/IconComponents/VIconSmartHome.vue
+++ b/src/components/atoms/IconComponents/VIconSmartHome.vue
@@ -11,14 +11,16 @@
     stroke-linejoin="round"
   >
     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-    <path d="M12 5l0 14"></path>
-    <path d="M5 12l14 0"></path>
+    <path
+      d="M19 8.71l-5.333 -4.148a2.666 2.666 0 0 0 -3.274 0l-5.334 4.148a2.665 2.665 0 0 0 -1.029 2.105v7.2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-7.2c0 -.823 -.38 -1.6 -1.03 -2.105"
+    ></path>
+    <path d="M16 15c-2.21 1.333 -5.792 1.333 -8 0"></path>
   </svg>
 </template>
 
 <script>
 export default {
-  name: "VPlusIcon",
+  name: "VIconSmartHome",
 };
 </script>
 

--- a/src/components/atoms/IconComponents/index.js
+++ b/src/components/atoms/IconComponents/index.js
@@ -1,5 +1,5 @@
-export { default as VBarbleOffIcon } from "./VBarbleOffIcon.vue";
-export { default as VCalendarTimeIcon } from "./VCalendarTimeIcon.vue";
-export { default as VChartAreaLineIcon } from "./VChartAreaLineIcon.vue";
-export { default as VPlusIcon } from "./VPlusIcon.vue";
-export { default as VSmartHomeIcon } from "./VSmartHomeIcon.vue";
+export { default as VIconBarbleOff } from "./VIconBarbleOff.vue";
+export { default as VIconCalendarTime } from "./VIconCalendarTime.vue";
+export { default as VIconChartAreaLine } from "./VIconChartAreaLine.vue";
+export { default as VIconPlus } from "./VIconPlus.vue";
+export { default as VIconSmartHome } from "./VIconSmartHome.vue";

--- a/src/components/atoms/VButtonCreateExercise.vue
+++ b/src/components/atoms/VButtonCreateExercise.vue
@@ -1,24 +1,24 @@
 <template>
   <router-link to="" exact>
-    <button class="btn-create-exercise">
-      <v-plus-icon class="btn-create-exercise__icon" />
+    <button class="button-create-exercise">
+      <v-icon-plus class="button-create-exercise__icon" />
     </button>
   </router-link>
 </template>
 
 <script>
-import { VPlusIcon } from "./IconComponents";
+import { VIconPlus } from "./IconComponents";
 
 export default {
   name: "VCreateExerciseButton",
   components: {
-    VPlusIcon,
+    VIconPlus,
   },
 };
 </script>
 
 <style lang="scss" scoped>
-.btn-create-exercise {
+.button-create-exercise {
   width: auto;
   height: auto;
   position: fixed;

--- a/src/components/molecules/VNavigation.vue
+++ b/src/components/molecules/VNavigation.vue
@@ -15,17 +15,17 @@
 
 <script>
 import {
-  VSmartHomeIcon,
-  VCalendarTimeIcon,
-  VChartAreaLineIcon,
+  VIconSmartHome,
+  VIconCalendarTime,
+  VIconChartAreaLine,
 } from "../atoms/IconComponents";
 
 export default {
   name: "VNavigation",
   components: {
-    VSmartHomeIcon,
-    VCalendarTimeIcon,
-    VChartAreaLineIcon,
+    VIconSmartHome,
+    VIconCalendarTime,
+    VIconChartAreaLine,
   },
   data() {
     return {};
@@ -35,15 +35,15 @@ export default {
       return [
         {
           pathUrl: "/",
-          iconComponent: "v-smart-home-icon",
+          iconComponent: "v-icon-smart-home",
         },
         {
           pathUrl: "",
-          iconComponent: "v-calendar-time-icon",
+          iconComponent: "v-icon-calendar-time",
         },
         {
           pathUrl: "",
-          iconComponent: "v-chart-area-line-icon",
+          iconComponent: "v-icon-chart-area-line",
         },
       ];
     },

--- a/src/components/pages/VPageHome.vue
+++ b/src/components/pages/VPageHome.vue
@@ -1,32 +1,32 @@
 <template>
-  <section class="homepage">
-    <h5 class="homepage__title">Traxercise</h5>
-    <div class="homepage__empty-list">
-      <v-barble-off-icon class="homepage__icon" />
-      <p class="homepage__description">you have no exercise</p>
+  <section class="page-home">
+    <h5 class="pagehome__title">Traxercise</h5>
+    <div class="pagehome-list">
+      <v-icon-barble-off class="pagehome__icon" />
+      <p class="pagehome__description">you have no exercise</p>
     </div>
-    <v-create-exercise-button />
+    <v-button-create-exercise />
     <v-navigation />
   </section>
 </template>
 
 <script>
-import { VBarbleOffIcon } from "../atoms/IconComponents";
+import { VIconBarbleOff } from "../atoms/IconComponents";
 import VNavigation from "../molecules/VNavigation.vue";
-import VCreateExerciseButton from "../atoms/VCreateExerciseButton.vue";
+import VButtonCreateExercise from "../atoms/VButtonCreateExercise.vue";
 
 export default {
-  name: "VHomepage",
+  name: "VPageHome",
   components: {
-    VBarbleOffIcon,
+    VIconBarbleOff,
     VNavigation,
-    VCreateExerciseButton,
+    VButtonCreateExercise,
   },
 };
 </script>
 
 <style lang="scss" scoped>
-.homepage {
+.pagehome {
   height: auto;
 
   &__title {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
-import VHomepage from "../components/pages/VHomepage.vue";
+import VPageHome from "../components/pages/VPageHome.vue";
 
 Vue.use(VueRouter);
 
@@ -10,7 +10,7 @@ const router = new VueRouter({
     {
       path: "/",
       name: "homepage",
-      component: VHomepage,
+      component: VPageHome,
     },
   ],
 });


### PR DESCRIPTION
**What issue/feature/bugfix/improvement did you solve?**
---
rename components to make them easier to read when they have a large number of components

**How you resolve the issue**
---
it is easier to name components starting with the highest-level (often most general) words and ending with more descriptive names. using general names first will make it neat and we can immediately know the type of component because the editor will generally sort component names by letter. 

based on :
https://v2.vuejs.org/v2/style-guide/?redirect=true#Order-of-words-in-component-names-strongly-recommended