### PR TITLE
fixing base name from vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ import fonts from "vite-plugin-fonts";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/traxercise/",
+  base: "/",
   plugins: [
     vue2(),
     vue2Jsx(),


### PR DESCRIPTION
**What issue/feature/bugfix/improvement did you solve?**
---
get a blank page error on the GitHub action workflow 

**How you resolve the issue**
---
remove `traxercize` on `base` in the vite config file