### PR TITLE
fix: change the route path for the page home

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,7 +9,7 @@ const router = new VueRouter({
   mode: "history",
   routes: [
     {
-      path: "/",
+      path: "/traxercise",
       name: "homepage",
       component: VPageHome,
     },


### PR DESCRIPTION
**What issue/feature/bugfix/improvement did you solve?**
---
get a blank page error on the GitHub action workflow 

**How you resolve the issue**
---
trying to change the root path `/` to `/traxercise` to solve the problem of blank pages 